### PR TITLE
Potential fix for code scanning alert no. 62: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-qa.yaml
+++ b/.github/workflows/code-qa.yaml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Code Quality Assurance
+permissions:
+    contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/AlexJSully/Small-Dev-Talk/security/code-scanning/62](https://github.com/AlexJSully/Small-Dev-Talk/security/code-scanning/62)

The correct fix is to add a `permissions` block with the least necessary privilege at either the root level of the workflow or for the specific job. Since this workflow appears to only require read access to repository contents (it checks out code and runs tests, but does not write anything back to the repository or interact with issues, pull requests, etc.), specifying `permissions: contents: read` at the root level is sufficient and preferred (applies to all jobs and avoids redundancy). This change should be made immediately after the `name:` key (before the `on:` key for clarity and convention).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
