### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,6 +1,6 @@
+name: Markdown Lint
 permissions:
     contents: read
-name: Markdown Lint
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/AlexJSully/Small-Dev-Talk/security/code-scanning/63](https://github.com/AlexJSully/Small-Dev-Talk/security/code-scanning/63)

To fix the problem, add an explicit `permissions` block to the workflow or the job to limit the permissions of the `GITHUB_TOKEN` to the minimum necessary. Since this Markdown lint job does not need any write access to the repository, you should add `permissions: contents: read` as either a top-level key (applies to all jobs) or at the job level. Since there is only one job, both approaches work, but top-level is preferable for simplicity and is the most common practice. Edit `.github/workflows/markdown-lint.yaml` to insert the following after the `name:` line and before `on:` (i.e., after line 1).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
